### PR TITLE
Add timestamps columns and update template save

### DIFF
--- a/cdb-mails.php
+++ b/cdb-mails.php
@@ -38,6 +38,8 @@ function cdb_mails_activate() {
         name varchar(255) NOT NULL,
         subject varchar(255) NOT NULL,
         body longtext NOT NULL,
+        created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         PRIMARY KEY  (id)
     ) $charset_collate;";
 

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -63,12 +63,13 @@ function cdb_mails_save_template( $data, $id = 0 ) {
         $wpdb->update(
             $table,
             array(
-                'name'    => $data['name'],
-                'subject' => $data['subject'],
-                'body'    => $data['body'],
+                'name'       => $data['name'],
+                'subject'    => $data['subject'],
+                'body'       => $data['body'],
+                'updated_at' => current_time( 'mysql' ),
             ),
             array( 'id' => $id ),
-            array( '%s', '%s', '%s' ),
+            array( '%s', '%s', '%s', '%s' ),
             array( '%d' )
         );
         return $id;
@@ -77,11 +78,13 @@ function cdb_mails_save_template( $data, $id = 0 ) {
     $wpdb->insert(
         $table,
         array(
-            'name'    => $data['name'],
-            'subject' => $data['subject'],
-            'body'    => $data['body'],
+            'name'       => $data['name'],
+            'subject'    => $data['subject'],
+            'body'       => $data['body'],
+            'created_at' => current_time( 'mysql' ),
+            'updated_at' => current_time( 'mysql' ),
         ),
-        array( '%s', '%s', '%s' )
+        array( '%s', '%s', '%s', '%s', '%s' )
     );
 
     return $wpdb->insert_id;


### PR DESCRIPTION
## Summary
- add `created_at` and `updated_at` columns to table creation
- record timestamps when inserting or updating templates

## Testing
- `php -l cdb-mails.php`
- `php -l inc/templates.php`
- `php -l inc/admin.php`
- `php -l inc/mailer.php`

------
https://chatgpt.com/codex/tasks/task_e_68896320f5688327a88f0b926f804c8c