### PR TITLE
Add automatic rating notification template

### DIFF
--- a/cdb-mails.php
+++ b/cdb-mails.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: cdb-mails
  * Description: Gestor básico de notificaciones por correo electrónico.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Author: Proyecto CdB
  * License: GPL v2 or later
  */
@@ -44,6 +44,9 @@ function cdb_mails_activate() {
     ) $charset_collate;";
 
     dbDelta( $sql );
+
+    // Crear plantilla por defecto si no existe.
+    cdb_mails_ensure_default_template();
 }
 
 function cdb_mails_deactivate() {

--- a/inc/mailer.php
+++ b/inc/mailer.php
@@ -12,5 +12,71 @@ if ( ! defined( 'ABSPATH' ) ) {
  * en futuras versiones del plugin.
  */
 function cdb_mails_send_email( $to, $subject, $message, $headers = array(), $attachments = array() ) {
-    // Aquí se implementará la lógica de envío
+    if ( empty( $to ) || ! is_email( $to ) ) {
+        return false;
+    }
+
+    if ( empty( $headers ) ) {
+        $headers = array( 'Content-Type: text/html; charset=UTF-8' );
+    }
+
+    return wp_mail( $to, $subject, $message, $headers, $attachments );
+}
+
+add_action( 'save_post_valoracion', 'cdb_mails_new_valoracion_notification', 10, 3 );
+
+/**
+ * Enviar notificación cuando se publique una nueva valoración.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ * @param bool    $update  Whether this is an existing post being updated.
+ */
+function cdb_mails_new_valoracion_notification( $post_id, $post, $update ) {
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+
+    if ( 'publish' !== $post->post_status ) {
+        return;
+    }
+
+    $employee_id = (int) get_post_meta( $post_id, 'empleado_id', true );
+    if ( ! $employee_id ) {
+        $employee_id = (int) $post->post_parent;
+    }
+
+    if ( ! $employee_id ) {
+        return;
+    }
+
+    $employee = get_post( $employee_id );
+    if ( ! $employee ) {
+        return;
+    }
+
+    $user = get_user_by( 'id', $employee->post_author );
+    if ( ! $user || ! is_email( $user->user_email ) ) {
+        return;
+    }
+
+    cdb_mails_ensure_default_template();
+    $template = cdb_mails_get_template_by_name( 'Nueva valoración recibida' );
+    if ( ! $template ) {
+        return;
+    }
+
+    $vars = array(
+        '{send_date}'          => date_i18n( get_option( 'date_format' ) ),
+        '{user_name}'          => $user->display_name,
+        '{bar_name}'           => get_post_meta( $post_id, 'bar_name', true ),
+        '{valoracion_resumen}' => wp_trim_words( $post->post_content, 55 ),
+        '{profile_url}'        => get_permalink( $employee_id ),
+        '{review_date}'        => get_the_date( get_option( 'date_format' ), $post_id ),
+    );
+
+    $subject = str_replace( array_keys( $vars ), array_values( $vars ), $template['subject'] );
+    $body    = str_replace( array_keys( $vars ), array_values( $vars ), $template['body'] );
+
+    cdb_mails_send_email( $user->user_email, $subject, $body );
 }


### PR DESCRIPTION
## Summary
- add notification template variables
- create default template if missing
- send HTML emails on valoraciones published
- bump plugin version to 0.3.0

## Testing
- `php -l cdb-mails.php`
- `php -l inc/templates.php`
- `php -l inc/mailer.php`
- `php -l inc/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_688971d9f7708327a8961e97a362108b