### PR TITLE
Send HTML emails by default

### DIFF
--- a/cdb-mails.php
+++ b/cdb-mails.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: cdb-mails
  * Description: Gestor básico de notificaciones por correo electrónico.
- * Version: 0.3.0
+ * Version: 0.3.1
  * Author: Proyecto CdB
  * License: GPL v2 or later
  */

--- a/inc/mailer.php
+++ b/inc/mailer.php
@@ -16,8 +16,26 @@ function cdb_mails_send_email( $to, $subject, $message, $headers = array(), $att
         return false;
     }
 
+    $content_type = 'Content-Type: text/html; charset=UTF-8';
+
     if ( empty( $headers ) ) {
-        $headers = array( 'Content-Type: text/html; charset=UTF-8' );
+        $headers = array( $content_type );
+    } else {
+        if ( ! is_array( $headers ) ) {
+            $headers = array( $headers );
+        }
+
+        $has_content_type = false;
+        foreach ( $headers as $header ) {
+            if ( stripos( $header, 'content-type' ) !== false ) {
+                $has_content_type = true;
+                break;
+            }
+        }
+
+        if ( ! $has_content_type ) {
+            $headers[] = $content_type;
+        }
     }
 
     return wp_mail( $to, $subject, $message, $headers, $attachments );

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -390,7 +390,7 @@ function cdb_mails_render_send_test_form( $id ) {
             $subject = str_replace( array_keys( $test_vars ), array_values( $test_vars ), $template['subject'] );
             $body    = str_replace( array_keys( $test_vars ), array_values( $test_vars ), $template['body'] );
 
-            $sent = wp_mail( $email, $subject, $body );
+            $sent = cdb_mails_send_email( $email, $subject, $body );
 
             if ( $sent ) {
                 echo '<div class="updated notice"><p>Email de prueba enviado correctamente a ' . esc_html( $email ) . '.</p></div>';


### PR DESCRIPTION
## Summary
- update email sender to always include HTML headers
- send test emails through the mailer function
- bump version to 0.3.1

## Testing
- `php -l inc/mailer.php`
- `php -l inc/templates.php`
- `php -l cdb-mails.php`


------
https://chatgpt.com/codex/tasks/task_e_688976e458788327b51dd4e5d3d72f3e