### PR TITLE
Automatic email on grafica review insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ El objetivo es proporcionar una base limpia para desarrollar un sistema de notif
 
 Se expone la función global `cdb_mails_send_new_review_notification( $review_id, $type )` para que otros plugins puedan disparar la notificación "Nueva valoración recibida".
 
+Desde la versión 0.3.3 el plugin también escucha los hooks
+`cdb_grafica_insert_bar_result` y `cdb_grafica_insert_empleado_result`,
+pensados para que el plugin **cdb-grafica** los lance tras insertar una
+valoración en sus tablas personalizadas. Al ejecutarse cualquiera de esos
+hooks se enviará automáticamente el aviso por correo utilizando la plantilla
+_Nueva valoración recibida_.
+
 - **$review_id**: identificador de la valoración en la tabla personalizada.
 - **$type**: puede ser `bar` o `empleado` según la tabla utilizada.
 

--- a/inc/mailer.php
+++ b/inc/mailer.php
@@ -47,6 +47,11 @@ function cdb_mails_send_email( $to, $subject, $message, $headers = array(), $att
 add_action( 'save_post_cdb_valoracion', 'cdb_mails_new_valoracion_notification', 10, 3 );
 add_action( 'save_post_valoracion', 'cdb_mails_new_valoracion_notification', 10, 3 );
 
+// Integración con cdb-grafica: recibir notificación cuando se inserta una
+// valoración directamente en las tablas personalizadas.
+add_action( 'cdb_grafica_insert_bar_result', 'cdb_mails_handle_bar_result', 10, 1 );
+add_action( 'cdb_grafica_insert_empleado_result', 'cdb_mails_handle_empleado_result', 10, 1 );
+
 /**
  * Enviar notificación cuando se publique una nueva valoración.
  *
@@ -108,4 +113,17 @@ function cdb_mails_new_valoracion_notification( $post_id, $post, $update ) {
     $body    = str_replace( array_keys( $vars ), array_values( $vars ), $template['body'] );
 
     cdb_mails_send_email( $user->user_email, $subject, $body );
+}
+
+/**
+ * Procesar inserciones directas en las tablas personalizadas de cdb-grafica.
+ * Estas funciones actúan como puente con el plugin de gráficas y llaman a la
+ * función global encargada de enviar la notificación.
+ */
+function cdb_mails_handle_bar_result( $review_id ) {
+    cdb_mails_send_new_review_notification( $review_id, 'bar' );
+}
+
+function cdb_mails_handle_empleado_result( $review_id ) {
+    cdb_mails_send_new_review_notification( $review_id, 'empleado' );
 }


### PR DESCRIPTION
## Summary
- log and display failures when email sending errors occur
- ensure the default template exists before sending
- integrate cdb-mails with cdb-grafica via `cdb_grafica_insert_*` hooks
- send notifications through the global wrapper function
- document automatic hooks in README

## Testing
- `php -l inc/functions.php`
- `php -l inc/mailer.php`


------
https://chatgpt.com/codex/tasks/task_e_688a263bfa5883278b4c412d23cb4124