### PR TITLE
Improve debug logging for review notifications

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -35,6 +35,9 @@ function cdb_mails_log( $message ) {
 function cdb_mails_send_new_review_notification( $review_id, $type ) {
     global $wpdb;
 
+    // Log de inicio de la función con los parámetros recibidos.
+    cdb_mails_log( sprintf( 'Iniciando envio de notificación. review_id=%d, type=%s', $review_id, $type ) );
+
     // Determinar tabla y obtener datos básicos.
     if ( $type === 'empleado' ) {
         $table = $wpdb->prefix . 'grafica_empleado_results';
@@ -43,6 +46,7 @@ function cdb_mails_send_new_review_notification( $review_id, $type ) {
             cdb_mails_log( 'No se encontró la valoración de empleado con ID ' . $review_id );
             return;
         }
+        cdb_mails_log( 'Valoración de empleado encontrada. Post ID ' . $row->post_id . ' / User ID ' . $row->user_id );
         $post_id = $row->post_id;
         $user_id = $row->user_id;
     } elseif ( $type === 'bar' ) {
@@ -52,6 +56,7 @@ function cdb_mails_send_new_review_notification( $review_id, $type ) {
             cdb_mails_log( 'No se encontró la valoración de bar con ID ' . $review_id );
             return;
         }
+        cdb_mails_log( 'Valoración de bar encontrada. Post ID ' . $row->post_id . ' / User ID ' . $row->user_id );
         $post_id = $row->post_id;
         $user_id = $row->user_id;
     } else {
@@ -64,6 +69,8 @@ function cdb_mails_send_new_review_notification( $review_id, $type ) {
         cdb_mails_log( 'Usuario sin email para la valoración ' . $review_id );
         return;
     }
+
+    cdb_mails_log( 'Se enviará notificación a ' . $user->user_email );
 
     // Obtener nombre del usuario valorado
     $user_name = $user->display_name;
@@ -93,6 +100,8 @@ function cdb_mails_send_new_review_notification( $review_id, $type ) {
         return;
     }
 
+    cdb_mails_log( 'Plantilla cargada correctamente. Procediendo al envío.' );
+
     // Sustituir variables en el cuerpo del email
     $search  = array( '{send_date}', '{user_name}', '{bar_name}', '{valoracion_resumen}', '{profile_url}', '{review_date}' );
     $replace = array( $send_date, $user_name, $bar_name, $valoracion_resumen, $profile_url, $review_date );
@@ -102,7 +111,9 @@ function cdb_mails_send_new_review_notification( $review_id, $type ) {
 
     // Enviar email utilizando el wrapper del plugin.
     $sent = cdb_mails_send_email( $user->user_email, $subject, $body );
-    if ( ! $sent ) {
+    if ( $sent ) {
+        cdb_mails_log( 'Notificación enviada correctamente a ' . $user->user_email );
+    } else {
         cdb_mails_log( 'Fallo al enviar la notificación al usuario ID ' . $user_id );
     }
 }

--- a/inc/mailer.php
+++ b/inc/mailer.php
@@ -16,6 +16,11 @@ function cdb_mails_send_email( $to, $subject, $message, $headers = array(), $att
         return false;
     }
 
+    // Registrar intento de envío para depuración.
+    if ( function_exists( 'cdb_mails_log' ) ) {
+        cdb_mails_log( 'Llamada a wp_mail() para ' . $to );
+    }
+
     $content_type = 'Content-Type: text/html; charset=UTF-8';
 
     if ( empty( $headers ) ) {
@@ -61,6 +66,9 @@ add_action( 'cdb_grafica_insert_empleado_result', 'cdb_mails_handle_empleado_res
  */
 function cdb_mails_new_valoracion_notification( $post_id, $post, $update ) {
     // Evitar envíos durante autosave o al actualizar una valoración existente.
+    if ( function_exists( 'cdb_mails_log' ) ) {
+        cdb_mails_log( 'Hook save_post_* disparado para post ' . $post_id );
+    }
     if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
         return;
     }
@@ -121,9 +129,15 @@ function cdb_mails_new_valoracion_notification( $post_id, $post, $update ) {
  * función global encargada de enviar la notificación.
  */
 function cdb_mails_handle_bar_result( $review_id ) {
+    if ( function_exists( 'cdb_mails_log' ) ) {
+        cdb_mails_log( 'Hook cdb_grafica_insert_bar_result recibido para ID ' . $review_id );
+    }
     cdb_mails_send_new_review_notification( $review_id, 'bar' );
 }
 
 function cdb_mails_handle_empleado_result( $review_id ) {
+    if ( function_exists( 'cdb_mails_log' ) ) {
+        cdb_mails_log( 'Hook cdb_grafica_insert_empleado_result recibido para ID ' . $review_id );
+    }
     cdb_mails_send_new_review_notification( $review_id, 'empleado' );
 }


### PR DESCRIPTION
## Summary
- add detailed logging to cdb_mails_send_new_review_notification
- log when wp_mail is triggered and when hooks fire

## Testing
- `php -l cdb-mails.php`
- `php -l inc/functions.php`
- `php -l inc/mailer.php`
- `php -l inc/templates.php`
- `php -l inc/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_688a2971e4f08327844f69d8b5b4f935